### PR TITLE
Force resellers to watch resellers category

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -13,6 +13,14 @@ module ::WatchCategory
     mcneel_group.users.each do |user|
       watched_categories = CategoryUser.lookup(user, :watching).pluck(:category_id)
       CategoryUser.set_notification_level_for_category(user, CategoryUser.notification_levels[:watching], mcneel_private_category.id) unless watched_categories.include?(mcneel_private_category.id)
+
+    reseller_category = Category.find_by_slug("resellers")
+    reseller_group = Group.find_by_name("resellers")
+    return if reseller_category.nil? || reseller_group.nil?
+
+    reseller_group.users.each do |user|
+      watched_categories = CategoryUser.lookup(user, :watching).pluck(:category_id)
+      CategoryUser.set_notification_level_for_category(user, CategoryUser.notification_levels[:watching], reseller_category.id) unless watched_categories.include?(reseller_category.id)
     end
   end
 end


### PR DESCRIPTION
Hi Arpit,

Can you please review my changes and make sure that I wrote valid ruby? If this looks good, please accept this pull request - my assumption is that it will push into our Discourse server and run just fine.

Alternately, you can change our discourse instance to point to my fork of the plug-in, and that will let us update it as we see fit.
